### PR TITLE
Fix DSASigner

### DIFF
--- a/src/cryptojwt/jws.py
+++ b/src/cryptojwt/jws.py
@@ -177,12 +177,12 @@ class DSASigner(Signer):
 
     def sign(self, msg, key):
         asn1sig = key.sign(msg, ec.ECDSA(self.hash_algorithm()))
-        (r,s) = decode_dss_signature(asn1sig)
+        (r, s) = decode_dss_signature(asn1sig)
         return int_to_bytes(r) + int_to_bytes(s)
 
     def verify(self, msg, sig, key):
         try:
-            (r,s) = self._split_raw_signature(sig)
+            (r, s) = self._split_raw_signature(sig)
             asn1sig = encode_dss_signature(r, s)
             key.verify(asn1sig, msg, ec.ECDSA(self.hash_algorithm()))
         except InvalidSignature as err:
@@ -195,7 +195,7 @@ class DSASigner(Signer):
         c_length = len(sig) // 2
         r = int_from_bytes(sig[:c_length], byteorder='big')
         s = int_from_bytes(sig[c_length:], byteorder='big')
-        return (r,s)
+        return (r, s)
 
 
 class PSSSigner(Signer):

--- a/src/cryptojwt/jws.py
+++ b/src/cryptojwt/jws.py
@@ -11,6 +11,8 @@ from cryptography.hazmat.primitives import hmac
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.asymmetric import utils
+from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature, encode_dss_signature
+from cryptography.utils import int_from_bytes, int_to_bytes
 
 try:
     from builtins import str
@@ -174,15 +176,26 @@ class DSASigner(Signer):
             raise UnSupported('algorithm: {}'.format(algorithm))
 
     def sign(self, msg, key):
-        return key.sign(msg, ec.ECDSA(self.hash_algorithm()))
+        asn1sig = key.sign(msg, ec.ECDSA(self.hash_algorithm()))
+        (r,s) = decode_dss_signature(asn1sig)
+        return int_to_bytes(r) + int_to_bytes(s)
 
     def verify(self, msg, sig, key):
         try:
-            key.verify(sig, msg, ec.ECDSA(self.hash_algorithm()))
+            (r,s) = self._split_raw(sig)
+            asn1sig = encode_dss_signature(r, s)
+            key.verify(asn1sig, msg, ec.ECDSA(self.hash_algorithm()))
         except InvalidSignature as err:
             raise BadSignature(err)
         else:
             return True
+
+    @staticmethod
+    def _split_raw(sig):
+        c_length = len(sig) // 2
+        r = int_from_bytes(sig[:c_length], byteorder='big')
+        s = int_from_bytes(sig[c_length:], byteorder='big')
+        return (r,s)
 
 
 class PSSSigner(Signer):

--- a/src/cryptojwt/jws.py
+++ b/src/cryptojwt/jws.py
@@ -182,7 +182,7 @@ class DSASigner(Signer):
 
     def verify(self, msg, sig, key):
         try:
-            (r,s) = self._split_raw(sig)
+            (r,s) = self._split_raw_signature(sig)
             asn1sig = encode_dss_signature(r, s)
             key.verify(asn1sig, msg, ec.ECDSA(self.hash_algorithm()))
         except InvalidSignature as err:
@@ -191,7 +191,7 @@ class DSASigner(Signer):
             return True
 
     @staticmethod
-    def _split_raw(sig):
+    def _split_raw_signature(sig):
         c_length = len(sig) // 2
         r = int_from_bytes(sig[:c_length], byteorder='big')
         s = int_from_bytes(sig[c_length:], byteorder='big')


### PR DESCRIPTION
The DSASigner encodes signatures in ASN.1 (X9.62), but JWS expects a plain r||s encoding. DSASigner.sign and DSASigner.verify needs to use [cryptography.hazmat.primitives.asymmetric.utils.decode_dss_signature](https://cryptography.io/en/latest/hazmat/primitives/asymmetric/utils/#cryptography.hazmat.primitives.asymmetric.utils.decode_dss_signature) and [cryptography.hazmat.primitives.asymmetric.utils.encode_dss_signature](https://cryptography.io/en/latest/hazmat/primitives/asymmetric/utils/#cryptography.hazmat.primitives.asymmetric.utils.encode_dss_signature).
