### PR TITLE
Fix alg matching in pick_key

### DIFF
--- a/src/cryptojwt/__init__.py
+++ b/src/cryptojwt/__init__.py
@@ -16,7 +16,7 @@ except ImportError:
 
 from binascii import unhexlify
 
-__version__ = '0.3.0'
+__version__ = '0.3.1'
 
 logger = logging.getLogger(__name__)
 

--- a/src/cryptojwt/jwt.py
+++ b/src/cryptojwt/jwt.py
@@ -43,7 +43,7 @@ def pick_key(keys, use, alg='', key_type='', kid=''):
             continue
 
         if key.kty == key_type:
-            if key.alg == '' or key.alg == alg:
+            if key.alg == '' or alg == '' or key.alg == alg:
                 if key.kid == '' or kid == '' or key.kid == kid:
                     res.append(key)
     return res

--- a/tests/test_5_jwt.py
+++ b/tests/test_5_jwt.py
@@ -95,3 +95,30 @@ def test_jwt_pack_encrypt_no_sign():
     info = bob.unpack(_jwt)
 
     assert set(info.keys()) == {'iat', 'iss', 'sub', 'aud'}
+
+
+def test_jwt_pack_and_unpack_with_alg():
+    alice = JWT(own_keys=ALICE_KEYS, iss=ALICE)
+    payload = {'sub': 'sub'}
+    _jwt = alice.pack(payload=payload)
+
+    from cryptojwt.jwk import KEYS
+    alice_jwks = {
+        "keys":
+            [{
+                "kty": "RSA",
+                "alg": "RS256",
+                "use": "sig",
+                "kid": "1",
+                "n": ALICE_PUB_KEYS[0].n,
+                "e": ALICE_PUB_KEYS[0].e
+            }]
+    }
+    alg_keys = KEYS()
+    alg_keys.load_dict(alice_jwks)
+
+    bob = JWT(rec_keys={ALICE: alg_keys})
+    info = bob.unpack(_jwt)
+
+    assert set(info.keys()) == {'iat', 'iss', 'sub', 'kid', 'aud'}
+


### PR DESCRIPTION
I noticed this problem when trying to verify JWT signatures with key entries that specified "alg". The simple solution was to make "alg" wildcard match like the "kid".
Another improvement could also be to supply the "alg" when picking keys for JWT signature verification. But I'vent examined the code enough to see if it has some other implications. 