### PR TITLE
use correct EC required parameters or thumbprint is wrong

### DIFF
--- a/src/cryptojwt/jwk/ec.py
+++ b/src/cryptojwt/jwk/ec.py
@@ -119,7 +119,7 @@ class ECKey(AsymmetricKey):
     public_members = AsymmetricKey.public_members[:]
     public_members.extend(["kty", "alg", "use", "kid", "crv", "x", "y"])
     # required attributes
-    required = ['kty','crv', 'x', 'y']
+    required = ['kty', 'crv', 'x', 'y']
 
     def __init__(self, kty="EC", alg="", use="", kid="", key=None,
                  crv="", x="", y="", d="", **kwargs):

--- a/src/cryptojwt/jwk/ec.py
+++ b/src/cryptojwt/jwk/ec.py
@@ -119,7 +119,7 @@ class ECKey(AsymmetricKey):
     public_members = AsymmetricKey.public_members[:]
     public_members.extend(["kty", "alg", "use", "kid", "crv", "x", "y"])
     # required attributes
-    required = ['crv', 'key', 'x', 'y']
+    required = ['kty','crv', 'x', 'y']
 
     def __init__(self, kty="EC", alg="", use="", kid="", key=None,
                  crv="", x="", y="", d="", **kwargs):

--- a/src/cryptojwt/tools/keygen.py
+++ b/src/cryptojwt/tools/keygen.py
@@ -71,7 +71,7 @@ def main():
 
     jwk_dict = jwk.serialize(private=True)
     print(json.dumps(jwk_dict, sort_keys=True, indent=4))
-    print("SHA-256: " + b64e(jwk.thumbprint('SHA-256')).decode(), file=sys.stderr)
+    print("SHA-256: " + jwk.thumbprint('SHA-256').decode(), file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/test_02_jwk.py
+++ b/tests/test_02_jwk.py
@@ -569,3 +569,22 @@ def test_appropriate():
 
     assert _j1.appropriate_for('sign')
     assert _j1.appropriate_for('encrypt') is False
+
+def test_thumbprint_ec():
+    jwk = key_from_jwk_dict({
+        "kty": "EC",
+        "crv": "P-256",
+        "x": "MJ05vpfkWoIce1MwUpZYAyotenxp4yYVHJuc6lN_J0o",
+        "y": "Kfzs5wbqnEWUlFElN8ErWEL5YL2WQ1yowxzHejlzlZ0"
+    })
+    thumbprint = "RCWR9g8NPt9iZeq-lh-qXbiFxXcU0_o1YLitDj3kpg0"
+    assert (jwk.thumbprint('SHA-256').decode()) == thumbprint
+
+def test_thumbprint_rsa():
+    jwk = key_from_jwk_dict({
+        "kty": "RSA",
+        "e": "AQAB",
+        "n": "3xIyjRLL1LYi2FULhN6koVwtsaixgXa5TBOMcq2EMsk_Fq-tSXmxA8ATYcUnuSGX3PGJ5pHwIF42eesIzQV5ypYklF0sLAkmkXow_TMDX0qoc4rdfc2prq-mzPWwGcYoRsjDKiSUFOUSKB41zQ6sMY2k4BWZVo1bEL0CVpVct1DDhqSME6uUKex9T2AbwWNvwFacrwJaWyKixBhiPSwVBn7dUWDnJiM39_4Lnw6JnriXcli-aJlPuXm5F_qspXL4Pfn9nR5Z9j9Qf7NFif7nVRyg8cx7OYTbbsoIbMYYG-boVPLL7ebEBZVIUysqH_WkNJlkl5m7gAs5DB_KfMx18Q",
+    })
+    thumbprint = "Q1wZMrouq_iCnG7mr2y03Zxf7iE9mie-y_Mfh9-Cgk0"
+    assert (jwk.thumbprint('SHA-256').decode()) == thumbprint


### PR DESCRIPTION
It turns out cryptojwt calculated the thumbprint for EC keys wrong because the list of required key parameters where wrong. Fixed now.