### PR TITLE
Fix otherInfo serialization according to RFC 7518

### DIFF
--- a/src/cryptojwt/jwe/jwe_ec.py
+++ b/src/cryptojwt/jwe/jwe_ec.py
@@ -34,7 +34,7 @@ def ecdh_derive_key(key, epk, apu, apv, alg, dk_len):
     shared_key = key.exchange(ec.ECDH(), epk)
     # Derive the key
     # AlgorithmID || PartyUInfo || PartyVInfo || SuppPubInfo
-    otherInfo = bytes(alg) + \
+    otherInfo = struct.pack("!I", len(alg)) + bytes(alg) + \
                 struct.pack("!I", len(apu)) + apu + \
                 struct.pack("!I", len(apv)) + apv + \
                 struct.pack("!I", dk_len)


### PR DESCRIPTION
This pull request aims to fix the ConcatKDF  key derivation operation to make it conform to the standard

RFC 7518 states in paragraph 4.6.2.  Key Derivation for ECDH Key Agreement 
>AlgorithmID
      The AlgorithmID value is of the form Datalen || Data, where Data
      is a variable-length string of zero or more octets, and Datalen is
      a fixed-length, big-endian 32-bit counter that indicates the
      length (in octets) of Data. ``
