### PR TITLE
Not modified fixes

### DIFF
--- a/src/cryptojwt/key_bundle.py
+++ b/src/cryptojwt/key_bundle.py
@@ -389,7 +389,7 @@ class KeyBundle:
 
         elif _http_resp.status_code == 304:  # Not modified
             LOGGER.debug("%s not modified since %s", self.source, self.last_remote)
-            pass
+            self.time_out = time.time() + self.cache_time
 
         else:
             LOGGER.warning("HTTP status %d reading remote JWKS from %s",

--- a/src/cryptojwt/key_bundle.py
+++ b/src/cryptojwt/key_bundle.py
@@ -392,6 +392,8 @@ class KeyBundle:
             pass
 
         else:
+            LOGGER.warning("HTTP status %d reading remote JWKS from %s",
+                           _http_resp.status_code, self.source)
             raise UpdateFailed(
                 REMOTE_FAILED.format(self.source, _http_resp.status_code))
         self.last_updated = time.time()

--- a/src/cryptojwt/key_bundle.py
+++ b/src/cryptojwt/key_bundle.py
@@ -304,7 +304,7 @@ class KeyBundle:
 
         :param filename: Name of the file from which the JWKS should be loaded
         """
-        LOGGER.debug("Reading JWKS from %s", filename)
+        LOGGER.info("Reading local JWKS from %s", filename)
         with open(filename) as input_file:
             _info = json.load(input_file)
         if 'keys' in _info:
@@ -322,7 +322,7 @@ class KeyBundle:
         :param keytype: Presently 'rsa' and 'ec' supported
         :param keyusage: encryption ('enc') or signing ('sig') or both
         """
-        LOGGER.debug("Reading DER from %s", filename)
+        LOGGER.info("Reading local DER from %s", filename)
         key_args = {}
         _kty = keytype.lower()
         if _kty in ['rsa', 'ec']:
@@ -354,6 +354,7 @@ class KeyBundle:
         # if self.verify_ssl is not None:
         #     self.httpc_params["verify"] = self.verify_ssl
 
+        LOGGER.info("Reading remote JWKS from %s", self.source)
         try:
             LOGGER.debug('KeyBundle fetch keys from: %s', self.source)
             httpc_params = self.httpc_params.copy()

--- a/tests/test_03_key_bundle.py
+++ b/tests/test_03_key_bundle.py
@@ -1014,7 +1014,7 @@ def test_remote_not_modified():
         assert kb.last_remote == headers.get("Last-Modified")
         timeout2 = kb.time_out
 
-    assert timeout1 == timeout2
+    assert timeout1 != timeout2
 
     exp = kb.dump()
     kb2 = KeyBundle().load(exp)


### PR DESCRIPTION
We need to update `time_out` on 304, or we'll keep asking the remote every time.

(includes commits from #44)
