### PR TITLE
Better exception handling for missing keys and issuers

### DIFF
--- a/src/cryptojwt/exception.py
+++ b/src/cryptojwt/exception.py
@@ -43,6 +43,10 @@ class MissingKey(JWKESTException):
     """ No usable key """
 
 
+class MissingIssuer(JWKESTException):
+    """No usable issuer"""
+
+
 class KeyIOError(Exception):
     pass
 

--- a/src/cryptojwt/exception.py
+++ b/src/cryptojwt/exception.py
@@ -43,8 +43,12 @@ class MissingKey(JWKESTException):
     """No usable key"""
 
 
-class MissingIssuer(JWKESTException):
-    """No usable issuer"""
+class KeyNotFound(KeyError):
+    """Key not found"""
+
+
+class IssuerNotFound(KeyError):
+    """Issuer not found"""
 
 
 class KeyIOError(Exception):

--- a/src/cryptojwt/exception.py
+++ b/src/cryptojwt/exception.py
@@ -40,7 +40,7 @@ class BadType(Invalid):
 
 
 class MissingKey(JWKESTException):
-    """ No usable key """
+    """No usable key"""
 
 
 class MissingIssuer(JWKESTException):

--- a/src/cryptojwt/key_jar.py
+++ b/src/cryptojwt/key_jar.py
@@ -467,7 +467,7 @@ class KeyJar(object):
         _issuer = self._get_issuer(issuer_id)
         if _issuer is None:
             logger.error('Issuer "{}" not in keyjar'.format(issuer_id))
-            return keys
+            raise IssuerNotFound(issuer_id)
 
         logger.debug('Key summary for {}: {}'.format(issuer_id, _issuer.key_summary()))
 

--- a/src/cryptojwt/key_jar.py
+++ b/src/cryptojwt/key_jar.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from requests import request
 
-from .exception import UnknownKeyType, KeyIOError, UpdateFailed
+from .exception import UnknownKeyType, KeyIOError, UpdateFailed, IssuerNotFound
 from .jwe.jwe import alg2keytype as jwe_alg2keytype
 from .jws.utils import alg2keytype as jws_alg2keytype
 from .key_bundle import KeyBundle
@@ -241,7 +241,7 @@ class KeyJar(object):
         """
         _issuer = self._get_issuer(issuer_id)
         if _issuer is None:
-            raise KeyError(issuer_id)
+            raise IssuerNotFound(issuer_id)
         return _issuer.all_keys()
 
     @deprecated_alias(issuer='issuer_id', owner='issuer_id')
@@ -262,7 +262,7 @@ class KeyJar(object):
         """
         _issuer = self._get_issuer(issuer_id)
         if _issuer is None:
-            raise KeyError(issuer_id)
+            raise IssuerNotFound(issuer_id)
         return _issuer
 
     @deprecated_alias(issuer='issuer_id', owner='issuer_id')
@@ -667,7 +667,7 @@ class KeyJar(object):
         if _issuer is not None:
             return _issuer.key_summary()
 
-        raise KeyError('Unknown Issuer ID: "{}"'.format(issuer_id))
+        raise IssuerNotFound(issuer_id)
 
     def update(self):
         """

--- a/src/cryptojwt/key_jar.py
+++ b/src/cryptojwt/key_jar.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 from requests import request
 
+from .exception import UnknownKeyType, KeyIOError, UpdateFailed
 from .jwe.jwe import alg2keytype as jwe_alg2keytype
 from .jws.utils import alg2keytype as jws_alg2keytype
 from .key_bundle import KeyBundle
@@ -18,18 +19,6 @@ from .utils import qualified_name
 __author__ = 'Roland Hedberg'
 
 logger = logging.getLogger(__name__)
-
-
-class KeyIOError(Exception):
-    pass
-
-
-class UnknownKeyType(KeyIOError):
-    pass
-
-
-class UpdateFailed(KeyIOError):
-    pass
 
 
 class KeyJar(object):

--- a/tests/test_04_key_jar.py
+++ b/tests/test_04_key_jar.py
@@ -5,7 +5,7 @@ import time
 
 import pytest
 
-from cryptojwt.exception import JWKESTException
+from cryptojwt.exception import JWKESTException, IssuerNotFound
 from cryptojwt.jwe.jwenc import JWEnc
 from cryptojwt.jws.jws import JWS
 from cryptojwt.jws.jws import factory
@@ -799,8 +799,8 @@ def test_get_decrypt_keys():
     keys = kj.get_jwt_decrypt_keys(jwt)
     assert keys
 
-    keys = kj.get_jwt_decrypt_keys(jwt, aud='Bob')
-    assert keys
+    with pytest.raises(IssuerNotFound):
+        keys = kj.get_jwt_decrypt_keys(jwt, aud='Bob')
 
 
 def test_update_keyjar():


### PR DESCRIPTION
- raise better exceptions when keys and issuers are not found
- still try to be backwards compatible (tests mostly agrees that we are)