### PR TITLE
Add option ignore_invalid_keys to KeyBundle

### DIFF
--- a/src/cryptojwt/key_bundle.py
+++ b/src/cryptojwt/key_bundle.py
@@ -162,6 +162,7 @@ class KeyBundle:
         keytype="RSA",
         keyusage=None,
         kid="",
+        accept_invalid_keys=True,
         httpc=None,
         httpc_params=None,
     ):
@@ -181,6 +182,7 @@ class KeyBundle:
             presently 'rsa' and 'ec' are supported.
         :param keyusage: What the key loaded from file should be used for.
             Only applicable for DER files
+        :param accept_invalid_keys: Accept invalid keys
         :param httpc: A HTTP client function
         :param httpc_params: Additional parameters to pass to the HTTP client
             function
@@ -202,6 +204,7 @@ class KeyBundle:
         self.last_updated = 0
         self.last_remote = None  # HTTP Date of last remote update
         self.last_local = None  # UNIX timestamp of last local update
+        self.accept_invalid_keys = accept_invalid_keys
 
         if httpc:
             self.httpc = httpc
@@ -274,6 +277,8 @@ class KeyBundle:
             elif inst["kty"].upper() in K2C:
                 inst["kty"] = inst["kty"].upper()
             else:
+                if not self.accept_invalid_keys:
+                    raise UnknownKeyType(inst)
                 LOGGER.warning("While loading keys, unknown key type: %s", inst["kty"])
                 continue
 
@@ -290,12 +295,18 @@ class KeyBundle:
                 try:
                     _key = K2C[_typ](use=_use, **inst)
                 except KeyError:
+                    if not self.accept_invalid_keys:
+                        raise UnknownKeyType(inst)
                     _error = "UnknownKeyType: {}".format(_typ)
                     continue
                 except (UnsupportedECurve, UnsupportedAlgorithm) as err:
+                    if not self.accept_invalid_keys:
+                        raise err
                     _error = str(err)
                     break
                 except JWKException as err:
+                    if not self.accept_invalid_keys:
+                        raise err
                     LOGGER.warning("While loading keys: %s", err)
                     _error = str(err)
                 else:

--- a/src/cryptojwt/key_bundle.py
+++ b/src/cryptojwt/key_bundle.py
@@ -162,7 +162,7 @@ class KeyBundle:
         keytype="RSA",
         keyusage=None,
         kid="",
-        accept_invalid_keys=True,
+        ignore_invalid_keys=True,
         httpc=None,
         httpc_params=None,
     ):
@@ -182,7 +182,7 @@ class KeyBundle:
             presently 'rsa' and 'ec' are supported.
         :param keyusage: What the key loaded from file should be used for.
             Only applicable for DER files
-        :param accept_invalid_keys: Accept invalid keys
+        :param ignore_invalid_keys: Ignore invalid keys
         :param httpc: A HTTP client function
         :param httpc_params: Additional parameters to pass to the HTTP client
             function
@@ -204,7 +204,7 @@ class KeyBundle:
         self.last_updated = 0
         self.last_remote = None  # HTTP Date of last remote update
         self.last_local = None  # UNIX timestamp of last local update
-        self.accept_invalid_keys = accept_invalid_keys
+        self.ignore_invalid_keys = ignore_invalid_keys
 
         if httpc:
             self.httpc = httpc
@@ -277,7 +277,7 @@ class KeyBundle:
             elif inst["kty"].upper() in K2C:
                 inst["kty"] = inst["kty"].upper()
             else:
-                if not self.accept_invalid_keys:
+                if not self.ignore_invalid_keys:
                     raise UnknownKeyType(inst)
                 LOGGER.warning("While loading keys, unknown key type: %s", inst["kty"])
                 continue
@@ -295,17 +295,17 @@ class KeyBundle:
                 try:
                     _key = K2C[_typ](use=_use, **inst)
                 except KeyError:
-                    if not self.accept_invalid_keys:
+                    if not self.ignore_invalid_keys:
                         raise UnknownKeyType(inst)
                     _error = "UnknownKeyType: {}".format(_typ)
                     continue
                 except (UnsupportedECurve, UnsupportedAlgorithm) as err:
-                    if not self.accept_invalid_keys:
+                    if not self.ignore_invalid_keys:
                         raise err
                     _error = str(err)
                     break
                 except JWKException as err:
-                    if not self.accept_invalid_keys:
+                    if not self.ignore_invalid_keys:
                         raise err
                     LOGGER.warning("While loading keys: %s", err)
                     _error = str(err)

--- a/tests/test_03_key_bundle.py
+++ b/tests/test_03_key_bundle.py
@@ -10,6 +10,7 @@ import requests
 import responses
 from cryptography.hazmat.primitives.asymmetric import rsa
 
+from cryptojwt.exception import UnknownKeyType
 from cryptojwt.jwk.ec import ECKey
 from cryptojwt.jwk.ec import new_ec_key
 from cryptojwt.jwk.hmac import SYMKey
@@ -1067,3 +1068,14 @@ def test_ignore_errors_period():
         kb.source = source_good
         res = kb.do_remote()
         assert res == True
+
+
+def test_accept_invalid_keys():
+    rsa_key_dict = new_rsa_key().serialize()
+    rsa_key_dict["kty"] = "b0rken"
+
+    kb = KeyBundle(keys={"keys": [rsa_key_dict]}, accept_invalid_keys=True)
+    assert len(kb) == 0
+
+    with pytest.raises(UnknownKeyType):
+        KeyBundle(keys={"keys": [rsa_key_dict]}, accept_invalid_keys=False)

--- a/tests/test_03_key_bundle.py
+++ b/tests/test_03_key_bundle.py
@@ -1070,12 +1070,12 @@ def test_ignore_errors_period():
         assert res == True
 
 
-def test_accept_invalid_keys():
+def test_ignore_invalid_keys():
     rsa_key_dict = new_rsa_key().serialize()
     rsa_key_dict["kty"] = "b0rken"
 
-    kb = KeyBundle(keys={"keys": [rsa_key_dict]}, accept_invalid_keys=True)
+    kb = KeyBundle(keys={"keys": [rsa_key_dict]}, ignore_invalid_keys=True)
     assert len(kb) == 0
 
     with pytest.raises(UnknownKeyType):
-        KeyBundle(keys={"keys": [rsa_key_dict]}, accept_invalid_keys=False)
+        KeyBundle(keys={"keys": [rsa_key_dict]}, ignore_invalid_keys=False)


### PR DESCRIPTION
- If set to True (default), silently ignore invalid keys.
- If set to False, raise exception when processing keys.

closes #63 