### PR TITLE
Human message regarding minimum client_secret lenght

### DIFF
--- a/src/cryptojwt/jwk/hmac.py
+++ b/src/cryptojwt/jwk/hmac.py
@@ -57,7 +57,7 @@ class SYMKey(JWK):
             self.key = b64d(bytes(self.k))
 
         if len(self.key) < 16:
-            raise UnsupportedAlgorithm("key too short")
+            raise UnsupportedAlgorithm("client_secret too short, it should be at least 16 digits")
 
     def deserialize(self):
         self.key = b64d(bytes(self.k))


### PR DESCRIPTION
A simple commit that wants to focus on an error message reported to users.

Standing on [CSCfi shib oidc op guide](https://github.com/CSCfi/shibboleth-idp-oidc-extension/wiki/Installing-from-archive) the example client_secret is `topsecret`. That's something that users tends to use as it is for test setups.

cryptojwt instead, have a default minimum length secret, as a policy, it seems quite hardcoded here:
https://github.com/IdentityPython/JWTConnect-Python-CryptoJWT/blob/030b1c6e5e884456494d9c073442f661724ccd28/src/cryptojwt/jwk/hmac.py#L59

I purpose a human readable message in this PR, to drive the users in a correct configuration (just to understand how thing should be done to get it to work). At the same time I'd think also to a global configuration parameters that could set that minimum value, an approch like:

````
min_secret_len = getattr(general_config, 'min_secret_len', 16)
````

This is a WiP, probably I'd add others stuffs here.
that's also a footprint on the test I made:

![image](https://user-images.githubusercontent.com/1297620/96253625-3f921400-0fb4-11eb-81f6-8cbb12f6d9da.png)
