### PR TITLE
cryptography.utils.int_from_bytes deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
 addons:
   apt:
     packages:
-      -
+      - rustc
 install:
   - pip install codecov
   - pip install tox tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ addons:
   apt:
     packages:
       - rustc
+      - cargo
 install:
   - pip install codecov
   - pip install tox tox-travis

--- a/src/cryptojwt/jws/dsa.py
+++ b/src/cryptojwt/jws/dsa.py
@@ -3,7 +3,6 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
 from cryptography.hazmat.primitives.asymmetric.utils import encode_dss_signature
-from cryptography.utils import int_from_bytes
 from cryptography.utils import int_to_bytes
 
 from ..exception import BadSignature
@@ -102,6 +101,6 @@ class ECDSASigner(Signer):
         :return: A 2-tuple
         """
         c_length = len(sig) // 2
-        r = int_from_bytes(sig[:c_length], byteorder="big")
-        s = int_from_bytes(sig[c_length:], byteorder="big")
+        r = int.from_bytes(sig[:c_length], byteorder="big")
+        s = int.from_bytes(sig[c_length:], byteorder="big")
         return r, s


### PR DESCRIPTION
xref: https://github.com/pyca/cryptography/blob/5511445e95a16fa12b464d57ace4bb17855fe844/src/cryptography/utils.py#L159