### PR TITLE
first cut at proper read/write locking for KeyBundle

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -404,6 +404,17 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "readerwriterlock"
+version = "1.0.8"
+description = "A python implementation of the three Reader-Writer problems."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+typing-extensions = "*"
+
+[[package]]
 name = "regex"
 version = "2020.11.13"
 description = "Alternative regular expression module, to replace re."
@@ -607,7 +618,7 @@ python-versions = "*"
 name = "typing-extensions"
 version = "3.7.4.3"
 description = "Backported and Experimental Type Hints for Python 3.5+"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -639,7 +650,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "a39019ac3af30b197f08099583fc06c61a9077638c3e351e34afd9ed019ef352"
+content-hash = "27c1fe3ba4fef2096f46f02e72a8b80b0d972f78ac6739d29af5d03609c49c52"
 
 [metadata.files]
 alabaster = [
@@ -908,6 +919,10 @@ pytest-isort = [
 pytz = [
     {file = "pytz-2021.1-py2.py3-none-any.whl", hash = "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"},
     {file = "pytz-2021.1.tar.gz", hash = "sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da"},
+]
+readerwriterlock = [
+    {file = "readerwriterlock-1.0.8-py3-none-any.whl", hash = "sha256:35c6277a4fdc23b7449025f708578a5069698bc7eea63ce7c6c50de175c71435"},
+    {file = "readerwriterlock-1.0.8.tar.gz", hash = "sha256:b806126d0c5ca90e84eb6f73a2bf9761df6c0b3184b9063bc229078cdf1464a7"},
 ]
 regex = [
     {file = "regex-2020.11.13-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:8b882a78c320478b12ff024e81dc7d43c1462aa4a3341c754ee65d857a521f85"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ jwtpeek = "cryptojwt.tools.jwtpeek:main"
 python = "^3.6"
 cryptography = "^3.4.6"
 requests = "^2.25.1"
+readerwriterlock = "^1.0.8"
 
 [tool.poetry.dev-dependencies]
 alabaster = "^0.7.12"

--- a/src/cryptojwt/key_bundle.py
+++ b/src/cryptojwt/key_bundle.py
@@ -834,6 +834,7 @@ class KeyBundle:
 
         return res
 
+    @keys_writer
     def load(self, spec):
         """
         Sets attributes according to a specification.

--- a/src/cryptojwt/key_bundle.py
+++ b/src/cryptojwt/key_bundle.py
@@ -575,7 +575,7 @@ class KeyBundle:
                 _typs = [typ.lower(), typ.upper()]
                 _keys = [k for k in self._keys if k.kty in _typs]
             else:
-                _keys = self._keys
+                _keys = copy.copy(self._keys)
 
         if only_active:
             return [k for k in _keys if not k.inactive_since]
@@ -591,7 +591,7 @@ class KeyBundle:
         if update:
             self._uptodate()
         with self._lock_reader:
-            return self._keys
+            return copy.copy(self._keys)
 
     def active_keys(self):
         """Return the set of active keys."""
@@ -792,9 +792,8 @@ class KeyBundle:
 
         return _bundle
 
-    @keys_reader
     def __iter__(self):
-        return self._keys.__iter__()
+        return self.keys().__iter__()
 
     def difference(self, bundle):
         """

--- a/src/cryptojwt/key_bundle.py
+++ b/src/cryptojwt/key_bundle.py
@@ -151,6 +151,14 @@ def ec_init(spec):
     return _kb
 
 
+def keys_reader(func):
+    def wrapper(self, *args, **kwargs):
+        with self._lock_reader:
+            return func(self, *args, **kwargs)
+
+    return wrapper
+
+
 def keys_writer(func):
     def wrapper(self, *args, **kwargs):
         with self._lock_writer:
@@ -655,6 +663,7 @@ class KeyBundle:
         except ValueError:
             pass
 
+    @keys_reader
     def __len__(self):
         """
         The number of keys.
@@ -760,8 +769,9 @@ class KeyBundle:
         return changed
 
     def __contains__(self, key):
-        return key in self._keys
+        return key in self.keys()
 
+    @keys_reader
     def copy(self):
         """
         Make deep copy of this KeyBundle
@@ -782,6 +792,7 @@ class KeyBundle:
 
         return _bundle
 
+    @keys_reader
     def __iter__(self):
         return self._keys.__iter__()
 


### PR DESCRIPTION
KeyBundle is tricky as it updates its own keys from multiple places in the code. This PR uses [readwriterlock](https://pypi.org/project/readerwriterlock/) to put a read lock around key reads and a write lock updates.

The write lock is implemented using a decorator, whereas the read lock implemented using explicit `with`. Most key access has been moved to `keys()` in order to simplify the code.

There may be dragons - please review carefully. Extra set of eyes from @janste63 would be most useful.