### PR TITLE
Timezone utc

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ exclude_lines = [
 
 [tool.poetry]
 name = "cryptojwt"
-version = "1.6.0"
+version = "1.6.1"
 description = "Python implementation of JWT, JWE, JWS and JWK"
 authors = ["Roland Hedberg <roland@catalogix.se>"]
 license = "Apache-2.0"

--- a/src/cryptojwt/jwt.py
+++ b/src/cryptojwt/jwt.py
@@ -3,6 +3,7 @@ import json
 import logging
 import uuid
 from datetime import datetime
+from datetime import timezone
 from json import JSONDecodeError
 
 from .exception import HeaderError
@@ -27,7 +28,9 @@ def utc_time_sans_frac():
 
     :return: A number of seconds
     """
-    return int(datetime.utcnow().timestamp())
+
+    now_timestampt = int(datetime.now(timezone.utc).timestamp())
+    return now_timestampt
 
 
 def pick_key(keys, use, alg="", key_type="", kid=""):


### PR DESCRIPTION
We need to keep `utc_time_sans_frac` in cryptojwt in sync with the implementation in oidcmsg until we can remove it from oidcmsg.