### PR TITLE
Correctly check content type

### DIFF
--- a/src/cryptojwt/key_bundle.py
+++ b/src/cryptojwt/key_bundle.py
@@ -30,6 +30,7 @@ from .jwk.jwk import import_jwk
 from .jwk.rsa import RSAKey
 from .jwk.rsa import new_rsa_key
 from .utils import as_unicode
+from .utils import check_content_type
 from .utils import httpc_params_loader
 
 __author__ = "Roland Hedberg"
@@ -513,8 +514,8 @@ class KeyBundle:
         """
         # Check if the content type is the right one.
         try:
-            if response.headers["Content-Type"] != "application/json":
-                LOGGER.warning("Wrong Content_type (%s)", response.headers["Content-Type"])
+            if not check_content_type(response.headers["Content-Type"], "application/json"):
+                LOGGER.warning("Wrong Content_type (%s)", respeonse.headers["Content-Type"])
         except KeyError:
             pass
 

--- a/src/cryptojwt/utils.py
+++ b/src/cryptojwt/utils.py
@@ -1,4 +1,5 @@
 import base64
+import cgi
 import functools
 import importlib
 import json
@@ -264,3 +265,9 @@ def httpc_params_loader(httpc_params):
     if "timeout" not in httpc_params:
         httpc_params["timeout"] = DEFAULT_HTTPC_TIMEOUT
     return httpc_params
+
+
+def check_content_type(content_type, mime_type):
+    """Return True if the content type contains the MIME type"""
+    mt, _ = cgi.parse_header(content_type)
+    return mime_type == mt

--- a/tests/test_31_utils.py
+++ b/tests/test_31_utils.py
@@ -1,0 +1,17 @@
+from cryptojwt.utils import check_content_type
+
+
+def test_check_content_type():
+    assert check_content_type(content_type="application/json", mime_type="application/json") == True
+    assert (
+        check_content_type(
+            content_type="application/json; charset=utf-8", mime_type="application/json"
+        )
+        == True
+    )
+    assert (
+        check_content_type(
+            content_type="application/html; charset=utf-8", mime_type="application/json"
+        )
+        == False
+    )


### PR DESCRIPTION
Current we log a warning if we receive `Content-Type: application/json; charset=utf-8`, but want `application/json`. This PR fixes this.

N.B. a charset option for JSON content is moot, since only utf8 may be used.