### PR TITLE
Fix key update

### DIFF
--- a/src/cryptojwt/key_bundle.py
+++ b/src/cryptojwt/key_bundle.py
@@ -546,7 +546,9 @@ class KeyBundle:
                     if self.fileformat in ["jwks", "jwk"]:
                         updated, new_keys = self._do_local_jwk(self.source)
                     elif self.fileformat == "der":
-                        updated, new_keys = self._do_local_der(self.source, self.keytype, self.keyusage)
+                        updated, new_keys = self._do_local_der(
+                            self.source, self.keytype, self.keyusage
+                        )
                 elif self.remote:
                     updated, new_keys = self._do_remote(set_keys=False)
                 else:


### PR DESCRIPTION
Found a problem in 1.7.0 when updating key bundles with a new set of keys, the old keys were lost.
Fixed typo in a log stmt.
To make this PR complete we should add a new test case to cover this.
