### PR TITLE
Prefer raw key to FernetEncrypter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ exclude_lines = [
 
 [tool.poetry]
 name = "cryptojwt"
-version = "1.8.1"
+version = "1.8.2"
 description = "Python implementation of JWT, JWE, JWS and JWK"
 authors = ["Roland Hedberg <roland@catalogix.se>"]
 license = "Apache-2.0"

--- a/src/cryptojwt/jwe/fernet.py
+++ b/src/cryptojwt/jwe/fernet.py
@@ -25,7 +25,13 @@ class FernetEncrypter(Encrypter):
     ):
         Encrypter.__init__(self)
 
-        if password is not None:
+        if key is not None:
+            if not isinstance(key, bytes):
+                raise TypeError("Raw key must be bytes")
+            if len(key) != 32:
+                raise ValueError("Raw key must be 32 bytes")
+            self.key = base64.urlsafe_b64encode(key)
+        elif password is not None:
             _alg = getattr(hashes, hash_alg)
             # A bit special for SHAKE* and BLAKE* hashes
             if hash_alg.startswith("SHAKE") or hash_alg.startswith("BLAKE"):
@@ -35,12 +41,6 @@ class FernetEncrypter(Encrypter):
             salt = as_bytes(salt) if salt else os.urandom(16)
             kdf = PBKDF2HMAC(algorithm=_algorithm, length=32, salt=salt, iterations=iterations)
             self.key = base64.urlsafe_b64encode(kdf.derive(as_bytes(password)))
-        elif key is not None:
-            if not isinstance(key, bytes):
-                raise TypeError("Raw key must be bytes")
-            if len(key) != 32:
-                raise ValueError("Raw key must be 32 bytes")
-            self.key = base64.urlsafe_b64encode(key)
         else:
             self.key = Fernet.generate_key()
 


### PR DESCRIPTION
If a pre-derived key is supplied to FernetEncrypter, prefer that to password/salt.