### PR TITLE
chore: JWT warnings on failed JWT ops

### DIFF
--- a/src/cryptojwt/jws/jws.py
+++ b/src/cryptojwt/jws/jws.py
@@ -228,12 +228,12 @@ class JWS(JWx):
             try:
                 if not verifier.verify(jwt.sign_input(), jwt.signature(), _key):
                     continue
-            except (BadSignature, IndexError):
-                pass
+            except (BadSignature, IndexError) as err:
+                logger.warning(f'BadSignature caught with {jwt}: "{err}"')
             except (ValueError, TypeError) as err:
-                logger.warning('Exception "{}" caught'.format(err))
+                logger.warning(f'Exception with {jwt.headers}: "{err}"')
             else:
-                logger.debug("Verified message using key with kid=%s" % key.kid)
+                logger.debug(f"Verified message using key with kid={key.kid}")
                 self.msg = jwt.payload()
                 self.key = key
                 self._protected_headers = jwt.headers.copy()

--- a/src/cryptojwt/jwt.py
+++ b/src/cryptojwt/jwt.py
@@ -374,9 +374,7 @@ class JWT:
         else:
             _msg_cls = self.iss2msg_cls.get(_info["iss"], None)
             if not _msg_cls:
-                LOGGER.debug(
-                    f"both msg_cls and iss2msg are None for the issuer {_info['iss']}"
-                )
+                LOGGER.debug(f"both msg_cls and iss2msg are None for the issuer {_info['iss']}")
 
         if _msg_cls:
             vp_args = {"skew": self.skew}

--- a/src/cryptojwt/jwt.py
+++ b/src/cryptojwt/jwt.py
@@ -372,11 +372,11 @@ class JWT:
         if self.msg_cls:
             _msg_cls = self.msg_cls
         else:
-            try:
-                # try to find a issuer specific message class
-                _msg_cls = self.iss2msg_cls[_info["iss"]]
-            except KeyError:
-                _msg_cls = None
+            _msg_cls = self.iss2msg_cls.get(_info["iss"], None)
+            if not _msg_cls:
+                LOGGER.debug(
+                    f"both msg_cls and iss2msg are None for the issuer {_info['iss']}"
+                )
 
         if _msg_cls:
             vp_args = {"skew": self.skew}


### PR DESCRIPTION
I'd like to have a warning meggase on failing JWT validations, or may use a debug for that and not a warning?

The messages must be improved.

actually with this PR we have

````
env/lib/python3.8/site-packages/idpyoidc/server/oidc/userinfo.py:191: KeyError
------------------------------------------------------------------------------------------------ Captured log call -------------------------------------------------------------------------------------------------
WARNING  cryptojwt.jwt:jwt.py:381 Exception unpacking a received signed or signed and encrypted Json Web Token for the issuer https://localhost:10000
WARNING  cryptojwt.jws.jws:jws.py:234 Exception "Invalid signature" caught
````