### PR TITLE
JWT check nbf/exp

### DIFF
--- a/src/cryptojwt/jwt.py
+++ b/src/cryptojwt/jwt.py
@@ -1,7 +1,6 @@
 """Basic JSON Web Token implementation."""
 import json
 import logging
-import time
 import uuid
 from datetime import datetime
 from datetime import timezone
@@ -383,7 +382,7 @@ class JWT:
             except KeyError:
                 _msg_cls = None
 
-        timestamp = timestamp or time.time()
+        timestamp = timestamp or utc_time_sans_frac()
 
         if "nbf" in _info:
             nbf = int(_info["nbf"])

--- a/src/cryptojwt/jwt.py
+++ b/src/cryptojwt/jwt.py
@@ -1,9 +1,8 @@
 """Basic JSON Web Token implementation."""
 import json
 import logging
+import time
 import uuid
-from datetime import datetime
-from datetime import timezone
 from json import JSONDecodeError
 
 from .exception import HeaderError
@@ -28,9 +27,7 @@ def utc_time_sans_frac():
 
     :return: A number of seconds
     """
-
-    now_timestampt = int(datetime.now(timezone.utc).timestamp())
-    return now_timestampt
+    return int(time.time())
 
 
 def pick_key(keys, use, alg="", key_type="", kid=""):

--- a/src/cryptojwt/jwt.py
+++ b/src/cryptojwt/jwt.py
@@ -312,7 +312,7 @@ class JWT:
         Unpack a received signed or signed and encrypted Json Web Token
 
         :param token: The Json Web Token
-        :param t: Time for evaluation (default now)
+        :param timestamp: Time for evaluation (default now)
         :return: If decryption and signature verification work the payload
             will be returned as a Message instance if possible.
         """

--- a/src/cryptojwt/jwt.py
+++ b/src/cryptojwt/jwt.py
@@ -179,13 +179,13 @@ class JWT:
 
         return _aud
 
-    def pack_init(self, recv, aud):
+    def pack_init(self, recv, aud, iat=None):
         """
         Gather initial information for the payload.
 
         :return: A dictionary with claims and values
         """
-        argv = {"iss": self.iss, "iat": utc_time_sans_frac()}
+        argv = {"iss": self.iss, "iat": iat or utc_time_sans_frac()}
         if self.lifetime:
             argv["exp"] = argv["iat"] + self.lifetime
 
@@ -210,7 +210,7 @@ class JWT:
 
         return keys[0]  # Might be more then one if kid == ''
 
-    def pack(self, payload=None, kid="", issuer_id="", recv="", aud=None, **kwargs):
+    def pack(self, payload=None, kid="", issuer_id="", recv="", aud=None, iat=None, **kwargs):
         """
 
         :param payload: Information to be carried as payload in the JWT
@@ -219,13 +219,14 @@ class JWT:
         :param recv: The intended immediate receiver
         :param aud: Intended audience for this JWS/JWE, not expected to
             contain the recipient.
+        :param iat: Override issued at (default current timestamp)
         :param kwargs: Extra keyword arguments
         :return: A signed or signed and encrypted Json Web Token
         """
         _args = {}
         if payload is not None:
             _args.update(payload)
-        _args.update(self.pack_init(recv, aud))
+        _args.update(self.pack_init(recv, aud, iat))
 
         try:
             _encrypt = kwargs["encrypt"]

--- a/tests/test_09_jwt.py
+++ b/tests/test_09_jwt.py
@@ -5,8 +5,9 @@ import pytest
 from cryptojwt.exception import IssuerNotFound
 from cryptojwt.jws.exception import NoSuitableSigningKeys
 from cryptojwt.jwt import JWT
-from cryptojwt.jwt import VerificationError, utc_time_sans_frac
+from cryptojwt.jwt import VerificationError
 from cryptojwt.jwt import pick_key
+from cryptojwt.jwt import utc_time_sans_frac
 from cryptojwt.key_bundle import KeyBundle
 from cryptojwt.key_jar import KeyJar
 from cryptojwt.key_jar import init_key_jar


### PR DESCRIPTION
- Check `nbf` and `exp` claims on JWT unpack
- Allow setting `iat` on JWT pack
- Allow setting maximum allowed token lifetime

**Discussion:** Do we want `nbf`/`exp` checking turned on by default (RFC 7519 compliant) or optional? One option would be to require the `timestamp` parameter to be set for time verification.