### PR TITLE
Cryptography fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ exclude_lines = [
 
 [tool.poetry]
 name = "cryptojwt"
-version = "1.9.0"
+version = "1.9.1"
 description = "Python implementation of JWT, JWE, JWS and JWK"
 authors = ["Roland Hedberg <roland@catalogix.se>"]
 license = "Apache-2.0"

--- a/src/cryptojwt/__init__.py
+++ b/src/cryptojwt/__init__.py
@@ -1,4 +1,5 @@
 """JSON Web Token"""
+
 import logging
 
 import pkg_resources

--- a/src/cryptojwt/jwe/aes.py
+++ b/src/cryptojwt/jwe/aes.py
@@ -1,7 +1,6 @@
 import os
 from struct import pack
 
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hmac
 from cryptography.hazmat.primitives.ciphers import Cipher
 from cryptography.hazmat.primitives.ciphers import algorithms
@@ -37,7 +36,7 @@ class AES_CBCEncrypter(Encrypter):
 
     def _mac(self, hash_key, hash_func, auth_data, iv, enc_msg, key_len):
         al = pack("!Q", 8 * len(auth_data))
-        h = hmac.HMAC(hash_key, hash_func(), backend=default_backend())
+        h = hmac.HMAC(hash_key, hash_func())
         h.update(auth_data)
         h.update(iv)
         h.update(enc_msg)
@@ -54,7 +53,7 @@ class AES_CBCEncrypter(Encrypter):
 
         hash_key, enc_key, key_len, hash_func = get_keys_seclen_dgst(self.key, iv)
 
-        cipher = Cipher(algorithms.AES(enc_key), modes.CBC(iv), backend=default_backend())
+        cipher = Cipher(algorithms.AES(enc_key), modes.CBC(iv))
         encryptor = cipher.encryptor()
 
         pmsg = self.padder.update(msg)
@@ -77,7 +76,7 @@ class AES_CBCEncrypter(Encrypter):
         if comp_tag != tag:
             raise VerificationError("AES-CBC HMAC")
 
-        cipher = Cipher(algorithms.AES(enc_key), modes.CBC(iv), backend=default_backend())
+        cipher = Cipher(algorithms.AES(enc_key), modes.CBC(iv))
         decryptor = cipher.decryptor()
 
         ctext = decryptor.update(msg)

--- a/src/cryptojwt/jwe/jwe_ec.py
+++ b/src/cryptojwt/jwe/jwe_ec.py
@@ -1,6 +1,5 @@
 import struct
 
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.keywrap import aes_key_unwrap
 from cryptography.hazmat.primitives.keywrap import aes_key_wrap
@@ -87,7 +86,7 @@ class JWE_EC(JWEKey):
         try:
             _epk = kwargs["epk"]
         except KeyError:
-            _epk = ec.generate_private_key(NIST2SEC[as_unicode(key.crv)], default_backend())
+            _epk = ec.generate_private_key(curve=NIST2SEC[as_unicode(key.crv)]())
             epk = ECKey().load_key(_epk.public_key())
         else:
             if isinstance(_epk, ec.EllipticCurvePrivateKey):
@@ -120,7 +119,7 @@ class JWE_EC(JWEKey):
             klen = int(_post[1:4])
             kek = ecdh_derive_key(_epk, key.pub_key, apu, apv, str(_post).encode(), klen)
             cek = self._generate_key(self.enc, cek=cek)
-            encrypted_key = aes_key_wrap(kek, cek, default_backend())
+            encrypted_key = aes_key_wrap(kek, cek)
         else:
             raise Exception("Unsupported algorithm %s" % self.alg)
 
@@ -172,7 +171,7 @@ class JWE_EC(JWEKey):
             _pre, _post = self.headers["alg"].split("+")
             klen = int(_post[1:4])
             kek = ecdh_derive_key(key, epubkey.pub_key, apu, apv, str(_post).encode(), klen)
-            self.cek = aes_key_unwrap(kek, token.encrypted_key(), default_backend())
+            self.cek = aes_key_unwrap(kek, token.encrypted_key())
         else:
             raise Exception("Unsupported algorithm %s" % self.headers["alg"])
 

--- a/src/cryptojwt/jwe/jwe_hmac.py
+++ b/src/cryptojwt/jwe/jwe_hmac.py
@@ -1,7 +1,6 @@
 import logging
 import zlib
 
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.keywrap import aes_key_unwrap
 from cryptography.hazmat.primitives.keywrap import aes_key_wrap
 
@@ -57,7 +56,7 @@ class JWE_SYM(JWEKey):
 
         # The iv for this function must be 64 bit
         # Which is certainly different from the one above
-        jek = aes_key_wrap(kek, cek, default_backend())
+        jek = aes_key_wrap(kek, cek)
 
         _enc = self["enc"]
         _auth_data = jwe.b64_encode_header()
@@ -85,7 +84,7 @@ class JWE_SYM(JWEKey):
                 except AttributeError:
                     key = key.key
             # The iv for this function must be 64 bit
-            cek = aes_key_unwrap(key, jek, default_backend())
+            cek = aes_key_unwrap(key, jek)
 
         auth_data = jwe.b64_protected_header()
         msg = self._decrypt(

--- a/src/cryptojwt/jwe/utils.py
+++ b/src/cryptojwt/jwe/utils.py
@@ -2,7 +2,6 @@ import os
 import struct
 from math import ceil
 
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.hashes import SHA256
 from cryptography.hazmat.primitives.hashes import SHA384
@@ -107,7 +106,7 @@ def concat_sha256(secret, dk_len, other_info):
     while len(dkm) < dk_bytes:
         counter += 1
         counter_bytes = struct.pack("!I", counter)
-        digest = hashes.Hash(hashes.SHA256(), backend=default_backend())
+        digest = hashes.Hash(hashes.SHA256())
         digest.update(counter_bytes)
         digest.update(secret)
         digest.update(other_info)

--- a/src/cryptojwt/jwk/ec.py
+++ b/src/cryptojwt/jwk/ec.py
@@ -1,4 +1,3 @@
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import ec
 
 from cryptojwt.exception import KeyNotFound
@@ -50,7 +49,7 @@ def ec_construct_public(num):
         raise UnsupportedECurve("Unsupported elliptic curve: {}".format(num["crv"]))
 
     ecpn = ec.EllipticCurvePublicNumbers(num["x"], num["y"], _sec_crv())
-    return ecpn.public_key(default_backend())
+    return ecpn.public_key()
 
 
 def ec_construct_private(num):
@@ -64,7 +63,7 @@ def ec_construct_private(num):
     """
     pub_ecpn = ec.EllipticCurvePublicNumbers(num["x"], num["y"], NIST2SEC[as_unicode(num["crv"])]())
     priv_ecpn = ec.EllipticCurvePrivateNumbers(num["d"], pub_ecpn)
-    return priv_ecpn.private_key(default_backend())
+    return priv_ecpn.private_key()
 
 
 class ECKey(AsymmetricKey):
@@ -285,7 +284,7 @@ def cmp_keys(a, b, key_type):
 
 
 def new_ec_key(crv, kid="", **kwargs):
-    _key = ec.generate_private_key(curve=NIST2SEC[crv], backend=default_backend())
+    _key = ec.generate_private_key(curve=NIST2SEC[crv]())
 
     _rk = ECKey(priv_key=_key, kid=kid, **kwargs)
     if not kid:

--- a/src/cryptojwt/jwk/jwk.py
+++ b/src/cryptojwt/jwk/jwk.py
@@ -2,7 +2,6 @@ import copy
 import json
 import os
 
-from cryptography.hazmat import backends
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric import ed448
 from cryptography.hazmat.primitives.asymmetric import ed25519
@@ -105,9 +104,7 @@ def key_from_jwk_dict(jwk_dict, private=None):
 
         if _jwk_dict.get("d", None) is not None:
             # Ecdsa private key.
-            _jwk_dict["priv_key"] = ec.derive_private_key(
-                base64url_to_long(_jwk_dict["d"]), curve, backends.default_backend()
-            )
+            _jwk_dict["priv_key"] = ec.derive_private_key(base64url_to_long(_jwk_dict["d"]), curve)
             _jwk_dict["pub_key"] = _jwk_dict["priv_key"].public_key()
         else:
             # Ecdsa public key.
@@ -116,7 +113,7 @@ def key_from_jwk_dict(jwk_dict, private=None):
                 base64url_to_long(_jwk_dict["y"]),
                 curve,
             )
-            _jwk_dict["pub_key"] = ec_pub_numbers.public_key(backends.default_backend())
+            _jwk_dict["pub_key"] = ec_pub_numbers.public_key()
         return ECKey(**_jwk_dict)
     elif _jwk_dict["kty"] == "RSA":
         ensure_rsa_params(_jwk_dict, private)
@@ -151,10 +148,10 @@ def key_from_jwk_dict(jwk_dict, private=None):
             rsa_priv_numbers = rsa.RSAPrivateNumbers(
                 p_long, q_long, d_long, dp_long, dq_long, qi_long, rsa_pub_numbers
             )
-            _jwk_dict["priv_key"] = rsa_priv_numbers.private_key(backends.default_backend())
+            _jwk_dict["priv_key"] = rsa_priv_numbers.private_key()
             _jwk_dict["pub_key"] = _jwk_dict["priv_key"].public_key()
         else:
-            _jwk_dict["pub_key"] = rsa_pub_numbers.public_key(backends.default_backend())
+            _jwk_dict["pub_key"] = rsa_pub_numbers.public_key()
 
         if _jwk_dict["kty"] != "RSA":
             raise WrongKeyType('"{}" should have been "RSA"'.format(_jwk_dict["kty"]))

--- a/src/cryptojwt/jwk/rsa.py
+++ b/src/cryptojwt/jwk/rsa.py
@@ -1,7 +1,6 @@
 import base64
 import logging
 
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
@@ -40,9 +39,7 @@ def generate_and_store_rsa_key(key_size=2048, filename="rsa.key", passphrase="")
     :return: A
         cryptography.hazmat.primitives.asymmetric.rsa.RSAPrivateKey instance
     """
-    private_key = rsa.generate_private_key(
-        public_exponent=65537, key_size=key_size, backend=default_backend()
-    )
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=key_size)
 
     with open(filename, "wb") as keyfile:
         if passphrase:
@@ -141,7 +138,7 @@ def x509_rsa_load(txt):
 
 def rsa_construct_public(numbers):
     rpn = rsa.RSAPublicNumbers(**numbers)
-    return rpn.public_key(default_backend())
+    return rpn.public_key()
 
 
 def rsa_construct_private(numbers):
@@ -181,7 +178,7 @@ def rsa_construct_private(numbers):
 
     rpubn = rsa.RSAPublicNumbers(e=numbers["e"], n=numbers["n"])
     rprivn = rsa.RSAPrivateNumbers(public_numbers=rpubn, **cnum)
-    return rprivn.private_key(default_backend())
+    return rprivn.private_key()
 
 
 def cmp_public_numbers(pn1, pn2):
@@ -492,9 +489,7 @@ def new_rsa_key(key_size=2048, kid="", public_exponent=65537, **kwargs):
     :return: A :py:class:`cryptojwt.jwk.rsa.RSAKey` instance
     """
 
-    _key = rsa.generate_private_key(
-        public_exponent=public_exponent, key_size=key_size, backend=default_backend()
-    )
+    _key = rsa.generate_private_key(public_exponent=public_exponent, key_size=key_size)
 
     _rk = RSAKey(priv_key=_key, kid=kid, **kwargs)
     if not _rk.kid:

--- a/src/cryptojwt/jwk/x509.py
+++ b/src/cryptojwt/jwk/x509.py
@@ -3,7 +3,6 @@ import hashlib
 import logging
 
 from cryptography import x509
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -22,7 +21,7 @@ def import_public_key_from_pem_file(filename):
     :return: A public key instance
     """
     with open(filename, "rb") as key_file:
-        public_key = serialization.load_pem_public_key(key_file.read(), backend=default_backend())
+        public_key = serialization.load_pem_public_key(key_file.read())
     return public_key
 
 
@@ -35,9 +34,7 @@ def import_private_key_from_pem_file(filename, passphrase=None):
     :return: A private key instance
     """
     with open(filename, "rb") as key_file:
-        private_key = serialization.load_pem_private_key(
-            key_file.read(), password=passphrase, backend=default_backend()
-        )
+        private_key = serialization.load_pem_private_key(key_file.read(), password=passphrase)
     return private_key
 
 
@@ -56,7 +53,7 @@ def import_public_key_from_pem_data(pem_data):
         pem_data = bytes("{}\n{}\n{}".format(PREFIX, pem_data, POSTFIX), "utf-8")
     else:
         pem_data = bytes(pem_data, "utf-8")
-    cert = x509.load_pem_x509_certificate(pem_data, default_backend())
+    cert = x509.load_pem_x509_certificate(pem_data)
     return cert.public_key()
 
 
@@ -68,7 +65,7 @@ def import_public_key_from_cert_file(filename):
     :return: A public key instance
     """
     with open(filename, "rb") as key_file:
-        cert = x509.load_pem_x509_certificate(key_file.read(), backend=default_backend())
+        cert = x509.load_pem_x509_certificate(key_file.read())
     return cert.public_key()
 
 
@@ -81,7 +78,7 @@ def der_cert(der_data):
     """
     if isinstance(der_data, str):
         der_data = bytes(der_data, "utf-8")
-    return x509.load_der_x509_certificate(der_data, default_backend())
+    return x509.load_der_x509_certificate(der_data)
 
 
 def load_x509_cert(url, httpc, spec2key, **get_args):

--- a/src/cryptojwt/jws/hmac.py
+++ b/src/cryptojwt/jws/hmac.py
@@ -1,4 +1,3 @@
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import hmac
 
@@ -26,7 +25,7 @@ class HMACSigner(Signer):
         :param key: The key
         :return: A signature
         """
-        h = hmac.HMAC(key, self.algorithm(), default_backend())
+        h = hmac.HMAC(key, self.algorithm())
         h.update(msg)
         return h.finalize()
 
@@ -41,7 +40,7 @@ class HMACSigner(Signer):
             Exception.
         """
         try:
-            h = hmac.HMAC(key, self.algorithm(), default_backend())
+            h = hmac.HMAC(key, self.algorithm())
             h.update(msg)
             h.verify(sig)
             return True

--- a/src/cryptojwt/jws/jws.py
+++ b/src/cryptojwt/jws/jws.py
@@ -1,4 +1,5 @@
 """JSON Web Token"""
+
 import json
 import logging
 

--- a/src/cryptojwt/jws/pss.py
+++ b/src/cryptojwt/jws/pss.py
@@ -1,7 +1,6 @@
 import logging
 
 from cryptography.exceptions import InvalidSignature
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.asymmetric import utils
@@ -32,7 +31,7 @@ class PSSSigner(Signer):
         :param key: The key
         :return: A signature
         """
-        hasher = hashes.Hash(self.hash_algorithm(), backend=default_backend())
+        hasher = hashes.Hash(self.hash_algorithm())
         hasher.update(msg)
         digest = hasher.finalize()
         sig = key.sign(

--- a/src/cryptojwt/jwt.py
+++ b/src/cryptojwt/jwt.py
@@ -1,4 +1,5 @@
 """Basic JSON Web Token implementation."""
+
 import json
 import logging
 import time

--- a/src/cryptojwt/jwx.py
+++ b/src/cryptojwt/jwx.py
@@ -1,4 +1,5 @@
 """A basic class on which to build the JWS and JWE classes."""
+
 import json
 import logging
 import warnings

--- a/tests/test_06_jws.py
+++ b/tests/test_06_jws.py
@@ -4,7 +4,6 @@ import json
 import os.path
 
 import pytest
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric import ed25519
 
@@ -307,7 +306,7 @@ SIGJWKS = KeyBundle(JWKS_b)
 
 
 def P256():
-    return ec.generate_private_key(ec.SECP256R1(), default_backend())
+    return ec.generate_private_key(curve=ec.SECP256R1())
 
 
 def test_1():
@@ -520,7 +519,7 @@ def test_jws_mm():
 )
 def test_signer_es(ec_func, alg):
     payload = "Please take a moment to register today"
-    eck = ec.generate_private_key(ec_func(), default_backend())
+    eck = ec.generate_private_key(curve=ec_func())
     keys = [ECKey().load_key(eck)]
     _jws = JWS(payload, alg=alg)
     _jwt = _jws.sign_compact(keys)
@@ -533,7 +532,7 @@ def test_signer_es(ec_func, alg):
 
 def test_signer_es256_verbose():
     payload = "Please take a moment to register today"
-    eck = ec.generate_private_key(ec.SECP256R1(), default_backend())
+    eck = ec.generate_private_key(curve=ec.SECP256R1())
     _key = ECKey().load_key(eck)
     keys = [_key]
     _jws = JWS(payload, alg="ES256")
@@ -695,7 +694,7 @@ def test_sign_2():
 
 def test_signer_protected_headers():
     payload = "Please take a moment to register today"
-    eck = ec.generate_private_key(ec.SECP256R1(), default_backend())
+    eck = ec.generate_private_key(curve=ec.SECP256R1())
     _key = ECKey().load_key(eck)
     keys = [_key]
     _jws = JWS(payload, alg="ES256")
@@ -719,7 +718,7 @@ def test_signer_protected_headers():
 
 def test_verify_protected_headers():
     payload = "Please take a moment to register today"
-    eck = ec.generate_private_key(ec.SECP256R1(), default_backend())
+    eck = ec.generate_private_key(curve=ec.SECP256R1())
     _key = ECKey().load_key(eck)
     keys = [_key]
     _jws = JWS(payload, alg="ES256")
@@ -743,7 +742,7 @@ def test_verify_protected_headers():
 
 
 def test_sign_json():
-    eck = ec.generate_private_key(ec.SECP256R1(), default_backend())
+    eck = ec.generate_private_key(curve=ec.SECP256R1())
     key = ECKey().load_key(eck)
     payload = "hello world"
     unprotected_headers = {"abc": "xyz"}
@@ -759,7 +758,7 @@ def test_sign_json():
 
 
 def test_verify_json():
-    eck = ec.generate_private_key(ec.SECP256R1(), default_backend())
+    eck = ec.generate_private_key(curve=ec.SECP256R1())
     key = ECKey().load_key(eck)
     payload = "hello world"
     unprotected_headers = {"abc": "xyz"}

--- a/tests/test_07_jwe.py
+++ b/tests/test_07_jwe.py
@@ -7,7 +7,6 @@ import string
 import sys
 
 import pytest
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import ec
 
 from cryptojwt.exception import BadSyntax
@@ -426,9 +425,9 @@ if __name__ == "__main__":
 
 # Test ECDH-ES
 
-alice = ec.generate_private_key(ec.SECP256R1(), default_backend())
+alice = ec.generate_private_key(curve=ec.SECP256R1())
 eck_alice = ECKey(priv_key=alice)
-bob = ec.generate_private_key(ec.SECP256R1(), default_backend())
+bob = ec.generate_private_key(curve=ec.SECP256R1())
 eck_bob = ECKey(priv_key=bob)
 
 


### PR DESCRIPTION
- remove deprecated cryptography backend arguments
- pass curve as instance and always pass as keyword argument
- bump version to 1.9.1

closes #157  
