### PR TITLE
Issuer instances need to have the same httpc_params specification as …

### DIFF
--- a/src/cryptojwt/key_jar.py
+++ b/src/cryptojwt/key_jar.py
@@ -133,6 +133,7 @@ class KeyJar(object):
         """
 
         issuer = self.return_issuer(issuer_id)
+        issuer.httpc_params = self.httpc_params
         kb = issuer.add_url(url, **kwargs)
         return kb
 


### PR DESCRIPTION
…the KeyJar they belong to.

At least that should be the default.