### PR TITLE
fix: don't overload primitives

### DIFF
--- a/src/cryptojwt/utils.py
+++ b/src/cryptojwt/utils.py
@@ -126,12 +126,12 @@ def b64d(b):
     return base64.urlsafe_b64decode(b)
 
 
-def b64e_enc_dec(str, encode="utf-8", decode="ascii"):
-    return b64e(str.encode(encode)).decode(decode)
+def b64e_enc_dec(datastr, encode="utf-8", decode="ascii"):
+    return b64e(datastr.encode(encode)).decode(decode)
 
 
-def b64d_enc_dec(str, encode="ascii", decode="utf-8"):
-    return b64d(str.encode(encode)).decode(decode)
+def b64d_enc_dec(datastr, encode="ascii", decode="utf-8"):
+    return b64d(datastr.encode(encode)).decode(decode)
 
 
 def as_bytes(s):


### PR DESCRIPTION
this PR removes the overload of the primitive `str`

generally, it would be preferable avoid also variables with single char names, like `b` or any other that might overload pdb commands