### PR TITLE
Use modern pypi publishing tool

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,12 +8,17 @@ jobs:
   pypi_release:
     name: Build with Poetry and Publish to PyPI
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/cryptojwt
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - name: Install and configure Poetry
-        run: |
-          pip install poetry
-          poetry config pypi-token.pypi "${{ secrets.PYPI_TOKEN }}"
+        run: pip install poetry
       - name: Publish package
-        run: poetry publish --build
+        run: poetry build
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Use modern PYPI publishing tool. Trusted Publisher Management now enabled in PYPI at https://pypi.org/manage/project/cryptojwt/settings/publishing/.
